### PR TITLE
Fix memory leak in timer observables.

### DIFF
--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
@@ -115,6 +115,11 @@ class TimerActivity : AppCompatActivity(), TimerContract.TimerView {
         }
     }
 
+    override fun onStop() {
+        super.onStop()
+        presenter.onStop()
+    }
+
     //endregion
 
     //region Menu interaction


### PR DESCRIPTION
Properly unsubscribe from TimerPresenter observables to avoid leaking context.