### PR TITLE
Config buddybuild CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# 20twenty20
+
+![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=577ef93b33bb590100edebbd&branch=master&build=latest)
+
+An Android utility to serve notifications for the [20-20-20 Rule](http://lifehacker.com/5591835/reduce-computer-caused-eye-strain-with-the-20-20-20-rule).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha4'
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,18 @@ allprojects {
     }
 }
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha4'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
Moves Gradle plugin version definition back to the root project (it was moved to the app module by the automatic Kotlin configuration) in order to avoid the ["could not find property vectorDrawable"](http://stackoverflow.com/questions/35693288/android-studio-1-5-1-could-not-find-property-vectordrawables) build error encountered by buddybuild.

Also adds a README with a build status badge.