### PR TITLE
Feature location-based automatic night mode 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,9 @@ dependencies {
     compile "com.artemzin.rxjava:proguard-rules:$rootProject.rxJavaProguardRulesVersion"
     compile "com.f2prateek.rx.preferences:rx-preferences:$rootProject.rxPreferencesVersion"
 
+    // Helpers
     compile "com.jakewharton.timber:timber:$rootProject.timberVersion"
+    compile "com.karumi:dexter:$rootProject.dexterVersion"
 
     compile "com.github.john990:WaveView:$rootProject.waveViewVersion"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.itsronald.twenty2020">
 
+    <!-- Permissions -->
+    <!-- Optionally used by AppCompat for automatic Night Mode. -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <!-- Application -->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <!-- Permissions -->
     <!-- Optionally used by AppCompat for automatic Night Mode. -->
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- Application -->
     <application

--- a/app/src/main/java/com/itsronald/twenty2020/Twenty2020Application.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/Twenty2020Application.kt
@@ -9,6 +9,7 @@ import com.itsronald.twenty2020.model.CycleModule
 import com.itsronald.twenty2020.model.DaggerCycleComponent
 import com.itsronald.twenty2020.settings.DaggerPreferencesComponent
 import com.itsronald.twenty2020.settings.PreferencesModule
+import com.karumi.dexter.Dexter
 import com.squareup.leakcanary.LeakCanary
 
 import timber.log.Timber
@@ -28,6 +29,7 @@ class Twenty2020Application : Application() {
             Timber.i("Timber logger planted.")
         }
         LeakCanary.install(this)
+        Dexter.initialize(this)
         useDefaultNightMode()
     }
 

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
@@ -178,6 +178,14 @@ class SettingsActivity : AppCompatPreferenceActivity(), SettingsContract.Setting
         }
     }
 
+    override fun removePreference(@StringRes prefKeyID: Int) {
+        val settingsFragment = fragmentManager
+                .findFragmentByTag(TAG_SETTINGS_FRAGMENT) as? SettingsFragment
+        settingsFragment?.findPreference(getString(prefKeyID))?.let {
+            settingsFragment.preferenceScreen?.removePreference(it)
+        }
+    }
+
     //endregion
 
     /**

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
@@ -180,6 +180,12 @@ class SettingsActivity : AppCompatPreferenceActivity(), SettingsContract.Setting
         }
     }
 
+    override fun setPreferenceEnabled(@StringRes prefKeyID: Int, enabled: Boolean): Boolean =
+        settingsFragment?.findPreference(getString(prefKeyID))?.let {
+            it.isEnabled = enabled
+            true
+        } ?: false
+
     override fun removePreference(@StringRes prefKeyID: Int): Boolean =
         settingsFragment?.findPreference(getString(prefKeyID))?.let {
             settingsFragment?.preferenceScreen?.removePreference(it)

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsActivity.kt
@@ -162,13 +162,15 @@ class SettingsActivity : AppCompatPreferenceActivity(), SettingsContract.Setting
     @Inject
     override lateinit var presenter: SettingsContract.Presenter
 
+    /** The SettingsFragment managing the PreferenceScreen. */
+    private val settingsFragment: SettingsFragment?
+        get() = fragmentManager.findFragmentByTag(TAG_SETTINGS_FRAGMENT) as? SettingsFragment
+
     override fun refreshNightMode(nightMode: Int) {
         if (delegate.applyDayNight()) recreate()
     }
 
     override fun setPreferenceChecked(@StringRes prefKeyID: Int, checked: Boolean): Boolean {
-        val settingsFragment = fragmentManager
-                .findFragmentByTag(TAG_SETTINGS_FRAGMENT) as? SettingsFragment
         val preference = settingsFragment?.findPreference(getString(prefKeyID)) as? TwoStatePreference
         if (preference == null) {
             return false
@@ -178,13 +180,10 @@ class SettingsActivity : AppCompatPreferenceActivity(), SettingsContract.Setting
         }
     }
 
-    override fun removePreference(@StringRes prefKeyID: Int) {
-        val settingsFragment = fragmentManager
-                .findFragmentByTag(TAG_SETTINGS_FRAGMENT) as? SettingsFragment
+    override fun removePreference(@StringRes prefKeyID: Int): Boolean =
         settingsFragment?.findPreference(getString(prefKeyID))?.let {
-            settingsFragment.preferenceScreen?.removePreference(it)
-        }
-    }
+            settingsFragment?.preferenceScreen?.removePreference(it)
+        } ?: false
 
     //endregion
 

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
@@ -32,6 +32,17 @@ interface SettingsContract {
          */
         fun setPreferenceChecked(@StringRes prefKeyID: Int, checked: Boolean): Boolean
 
+
+        /**
+         * Find and disable user interaction with the Preference item associated with a given key.
+         *
+         * @param prefKeyID The resource ID of the String key of the Preference to modify.
+         * @param enabled Whether to enable or disable the Preference associated with [prefKeyID].
+         *
+         * @return Whether or not the preference was found and modified.
+         */
+        fun setPreferenceEnabled(@StringRes prefKeyID: Int, enabled: Boolean): Boolean
+
         /**
          * Remove a preference item with key [prefKeyID] from the view.
          *

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
@@ -31,6 +31,13 @@ interface SettingsContract {
          * [checked]; false otherwise.
          */
         fun setPreferenceChecked(@StringRes prefKeyID: Int, checked: Boolean): Boolean
+
+        /**
+         * Remove a preference item with key [prefKeyID] from the view.
+         *
+         * @param prefKeyID The resource ID of the String key of the Preference to hide.
+         */
+        fun removePreference(@StringRes prefKeyID: Int)
     }
 
     interface Presenter : com.itsronald.twenty2020.base.Presenter<SettingsView> {

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
@@ -1,11 +1,17 @@
 package com.itsronald.twenty2020.settings
 
+import android.support.annotation.StringRes
+import android.view.ViewGroup
 import com.itsronald.twenty2020.base.View
 
 
 interface SettingsContract {
 
     interface SettingsView : View<Presenter> {
+
+        /** The view used by Dexter to display permission denied warnings. */
+        val contentView: ViewGroup
+
         /**
          * Notify the view that the global night mode has changed and that it may need to refresh
          * its layout.
@@ -13,6 +19,18 @@ interface SettingsContract {
          * @param nightMode The new global night mode preference.
          */
         fun refreshNightMode(nightMode: Int)
+
+        /**
+         * Attempt to set the switch value of a two-state preference with key accessible
+         * via [prefKeyID].
+         *
+         * @param prefKeyID The resource ID of the String key of the Preference to modify.
+         * @param checked The value to set for the preference's state.
+         *
+         * @return true if [prefKeyID] led to a valid two-state preference whose value was set to
+         * [checked]; false otherwise.
+         */
+        fun setPreferenceChecked(@StringRes prefKeyID: Int, checked: Boolean): Boolean
     }
 
     interface Presenter : com.itsronald.twenty2020.base.Presenter<SettingsView> {

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsContract.kt
@@ -36,8 +36,10 @@ interface SettingsContract {
          * Remove a preference item with key [prefKeyID] from the view.
          *
          * @param prefKeyID The resource ID of the String key of the Preference to hide.
+         *
+         * @return Whether or not the preference was found and removed.
          */
-        fun removePreference(@StringRes prefKeyID: Int)
+        fun removePreference(@StringRes prefKeyID: Int): Boolean
     }
 
     interface Presenter : com.itsronald.twenty2020.base.Presenter<SettingsView> {

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsPresenter.kt
@@ -1,8 +1,13 @@
 package com.itsronald.twenty2020.settings
 
+import android.Manifest
+import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatDelegate
 import com.f2prateek.rx.preferences.RxSharedPreferences
 import com.itsronald.twenty2020.R
+import com.karumi.dexter.Dexter
+import com.karumi.dexter.listener.single.SnackbarOnDeniedPermissionListener
 import rx.Observable
 import rx.android.schedulers.AndroidSchedulers
 import rx.lang.kotlin.onError
@@ -44,7 +49,21 @@ class SettingsPresenter
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to observe night mode setting.") }
 
+    private fun watchNightModeLocationPreference(): Observable<Boolean> = preferences
+            .getBoolean(view.context.getString(R.string.pref_key_display_location_based_night_mode))
+            .asObservable()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .onError { Timber.e(it, "Unable to observe night mode location setting.") }
+
     //endregion
+
+    //region Activity lifecycle
+
+    override fun onCreate(bundle: Bundle?) {
+        super.onCreate(bundle)
+        Dexter.initialize(view.context)
+    }
 
     override fun onStart() {
         super.onStart()
@@ -53,8 +72,17 @@ class SettingsPresenter
         startSubscriptions()
     }
 
+    override fun onStop() {
+        super.onStop()
+        Timber.v("SettingsPresenter is stopping.")
+        subscriptions.unsubscribe()
+    }
+
+    //endregion
+
     private fun startSubscriptions() {
         subscriptions = CompositeSubscription()
+
         subscriptions.add(watchNightModePreference().subscribe {
             val nightModeName = when (it) {
                 AppCompatDelegate.MODE_NIGHT_AUTO -> "MODE_NIGHT_AUTO"
@@ -66,11 +94,27 @@ class SettingsPresenter
             AppCompatDelegate.setDefaultNightMode(it)
             view.refreshNightMode(it)
         })
+
+        subscriptions.add(watchNightModeLocationPreference().subscribe { enabled ->
+            if (enabled) ensureLocationPermission()
+        })
     }
 
-    override fun onStop() {
-        super.onStop()
-        Timber.v("SettingsPresenter is stopping.")
-        subscriptions.unsubscribe()
+    private fun ensureLocationPermission() {
+        val snackbarPermissionListener = SnackbarOnDeniedPermissionListener.Builder
+                .with(view.contentView, R.string.location_permission_rationale)
+                .withOpenSettingsButton(R.string.settings)
+                .withCallback(object : Snackbar.Callback() {
+                    override fun onShown(snackbar: Snackbar?) {
+                        super.onShown(snackbar)
+                        // Un-check the setting if permission is denied.
+                        view.setPreferenceChecked(
+                                prefKeyID = R.string.pref_key_display_location_based_night_mode,
+                                checked = false
+                        )
+                    }
+                })
+                .build()
+        Dexter.checkPermission(snackbarPermissionListener, Manifest.permission.ACCESS_COARSE_LOCATION)
     }
 }

--- a/app/src/main/java/com/itsronald/twenty2020/settings/SettingsPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/settings/SettingsPresenter.kt
@@ -123,7 +123,7 @@ class SettingsPresenter
 
         Timber.v("Requesting permission ${Manifest.permission.ACCESS_COARSE_LOCATION}.")
         Dexter.checkPermission(buildDexterPermissionDeniedListener(),
-                Manifest.permission.ACCESS_COARSE_LOCATION)
+                Manifest.permission.ACCESS_FINE_LOCATION)
     }
 
     /**

--- a/app/src/main/res/values/strings_prefs.xml
+++ b/app/src/main/res/values/strings_prefs.xml
@@ -108,6 +108,9 @@
     <string name="pref_summary_display_location_based_night_mode_off">Use default sunrise/sunset (6 a.m./10 p.m.)</string>
     <string name="pref_key_display_location_based_night_mode"
         translatable="false">com.itsronald.settings.key.night_mode_uses_location</string>
+    <string name="location_permission_rationale">
+        Location permission is required to calculate night mode sunrise and sunset times.
+    </string>
 
     <string name="pref_title_display_keep_screen_on">Keep screen on</string>
     <string name="pref_key_display_keep_screen_on"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shouldDisableView="true" >
 
     <!-- General -->
     <PreferenceCategory android:title="@string/pref_header_general">
@@ -34,7 +36,6 @@
             android:title="@string/pref_title_display_location_based_night_mode"
             android:key="@string/pref_key_display_location_based_night_mode"
             android:defaultValue="false"
-            android:dependency="@string/pref_key_display_night_mode"
             android:summaryOn="@string/pref_summary_display_location_based_night_mode_on"
             android:summaryOff="@string/pref_summary_display_location_based_night_mode_off"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     javaAnnotationsVersion = "1.0"
 
     timberVersion = "4.1.2"
-    dexterVersion = "2.2.2"
+    dexterVersion = "2.3.0"
 
     waveViewVersion = "3da6d4b"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
     javaAnnotationsVersion = "1.0"
 
     timberVersion = "4.1.2"
+    dexterVersion = "2.2.2"
 
     waveViewVersion = "3da6d4b"
 }


### PR DESCRIPTION
Use `Theme.DayNight`'s automatic night mode feature, which requires location permissions.

## Pre-Android M
The location permission is granted on installation, so the setting is hidden entirely.

## Android M+
A preference is exposed below the night mode setting that is enabled when the night mode is set to `MODE_NIGHT_AUTO`. 

If the user checks the preference, they are prompted to give the app location access. 

Unchecking the preference will not remove the location permission, but removing the location permission or denying requests for access will cause the preference to be unchecked.