### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,9 +67,13 @@ kapt {
 dependencies {
     // Tools
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     debugCompile "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
     testCompile "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
+    // Silences warnings from LeakCanary v1.4-beta2; see http://stackoverflow.com/a/38255810/4499783
+    debugCompile "com.squareup.haha:haha:$rootProject.hahaVersion"
+
     compile "com.android.support.constraint:constraint-layout:$rootProject.constraintLibVersion"
 
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
     compileSdkVersion = 24
     buildToolsVersion = "24.0.1"
     leakCanaryVersion = "1.4-beta2"
+    hahaVersion = "2.0.3"
 
     // App dependencies
     supportLibraryVersion = "24.1.1"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 
     // App dependencies
     supportLibraryVersion = "24.1.1"
-    constraintLibVersion = "1.0.0-alpha3"
+    constraintLibVersion = "1.0.0-alpha4"
 
     rxJavaVersion = "1.1.5"
     rxJavaProguardRulesVersion = "$rxJavaVersion.0"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     supportLibraryVersion = "24.1.1"
     constraintLibVersion = "1.0.0-alpha4"
 
-    rxJavaVersion = "1.1.5"
+    rxJavaVersion = "1.1.8"
     rxJavaProguardRulesVersion = "$rxJavaVersion.0"
     rxAndroidVersion = "1.2.0"
     rxKotlinVersion = "0.55.0"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     leakCanaryVersion = "1.4-beta2"
 
     // App dependencies
-    supportLibraryVersion = "24.1.0"
+    supportLibraryVersion = "24.1.1"
     constraintLibVersion = "1.0.0-alpha3"
 
     rxJavaVersion = "1.1.5"


### PR DESCRIPTION
Updates the following dependencies:

* Android Support libs: **24.1.0** -> **24.1.1**
* RxJava: **1.1.5** -> **1.1.8**
* RxJava Proguard Rules: **1.1.5.0** -> **1.1.8.0**

And gets rid of LeakCanary build warnings caused by its outdated Haha dependency. See http://stackoverflow.com/a/38255810/4499783 for more details.