### PR TITLE
Update AboutLibraries version from 5.7.1 to 5.7.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
 
     waveViewVersion = "3da6d4b"
     showcaseViewVersion = "5.4.3"
-    aboutLibsVersion = "5.7.1@aar"
+    aboutLibsVersion = "5.7.3@aar"
     issueReporterVersion = "1.2.6"
 
     // Testing


### PR DESCRIPTION
Fixes https://trello.com/c/jH9IVSB9.

See: https://github.com/mikepenz/AboutLibraries/issues/238