### PR TITLE
Replace support-v4 dependency with new individual library dependencies.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,7 +93,9 @@ dependencies {
 
     // Android Support Libs
     compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
-    compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
+    compile "com.android.support:support-compat:$rootProject.supportLibraryVersion"
+    compile "com.android.support:support-core-utils:$rootProject.supportLibraryVersion"
+    compile "com.android.support:support-core-ui:$rootProject.supportLibraryVersion"
     compile "com.android.support:design:$rootProject.supportLibraryVersion"
     compile "com.android.support:support-vector-drawable:$rootProject.supportLibraryVersion"
     compile "com.android.support:percent:$rootProject.supportLibraryVersion"


### PR DESCRIPTION
This is now possible due to Android Support Library [revision 24.2.0](https://developer.android.com/topic/libraries/support-library/revisions.html#24-2-0-v4-refactor).