### PR TITLE
Fix short alarms

### DIFF
--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
@@ -1,5 +1,6 @@
 package com.itsronald.twenty2020.timer
 
+import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -14,6 +15,7 @@ import android.support.v7.content.res.AppCompatResources
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.animation.LinearInterpolator
 import android.widget.RelativeLayout
 import com.github.amlcurran.showcaseview.ShowcaseView
 import com.github.amlcurran.showcaseview.targets.ViewTarget
@@ -420,7 +422,7 @@ class TimerActivity : AppCompatActivity(), TimerContract.TimerView {
 
         (seekBar.parent as? View)?.alpha = 0.65f
 
-        seekBar.progress = 0f
+        animate(seekBar, toProgress = 0f)
     }
 
     override fun showWorkTimeRemaining(formattedTime: String) {
@@ -435,14 +437,27 @@ class TimerActivity : AppCompatActivity(), TimerContract.TimerView {
         if (work_seek_bar.max != maxProgress.toFloat()) {
             work_seek_bar.max = maxProgress.toFloat()
         }
-        work_seek_bar.progress = -progress.toFloat()
+        animate(seekBar = work_seek_bar, toProgress = -progress.toFloat())
     }
 
     override fun showBreakProgress(progress: Int, maxProgress: Int) {
         if (break_seek_bar.max != maxProgress.toFloat()) {
             break_seek_bar.max = maxProgress.toFloat()
         }
-        break_seek_bar.progress = progress.toFloat()
+        animate(seekBar = break_seek_bar, toProgress = progress.toFloat())
+    }
+
+    private fun animate(seekBar: CircularSeekBar, toProgress: Float): ObjectAnimator {
+        val objectAnimator = ObjectAnimator
+                .ofFloat(seekBar, "progress", seekBar.progress, toProgress)
+        objectAnimator.interpolator = LinearInterpolator()
+        objectAnimator.duration = 2000
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            objectAnimator.setAutoCancel(true)
+        }
+
+        objectAnimator.start()
+        return objectAnimator
     }
 
     override fun setFABDrawable(@DrawableRes drawableId: Int) {


### PR DESCRIPTION
Previously we switched from using `AlarmManager` for short alarms (< one minute away) to a delayed event posting directly from our app process because the interface with `AlarmManager` was not working for those durations.

Preliminary testing shows this might not be necessary after moving `AlarmReceiver`'s work to its own `IntentService` in #53 and in fact can result in these short alarms being suspended until the app process is in the foreground.