### PR TITLE
Remove timer start UI lag

### DIFF
--- a/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
@@ -177,7 +177,12 @@ class Cycle
                 .subscribeOn(Schedulers.computation())
                 .onError { timerSubject.onError(it) }
                 .doOnCompleted { startNext(delay = 0) }
-                .doOnSubscribe { running = true }
+                .doOnSubscribe {
+                    running = true
+                    if (timerSubject.hasObservers()) {
+                        timerSubject.onNext(this)
+                    }
+                }
                 .subscribe {
                     elapsedTime += 1
                     if (timerSubject.hasObservers()) {

--- a/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
@@ -122,9 +122,8 @@ class Cycle
     /** Subject where TimerControl events should be published. */
     private val timerEventSubject = PublishSubject.create<@TimerEvent Long>().toSerialized()
 
+    /** Subject where phase progress updates should be published. */
     private val timerProgressSubject = PublishSubject.create<Phase.Progress>().toSerialized()
-
-    val timerProgress: Observable<Phase.Progress> = timerProgressSubject.asObservable().onBackpressureLatest()
 
     //endregion
 
@@ -149,6 +148,12 @@ class Cycle
      * @return The full duraton of [phase] in seconds.
      */
     fun durationOfPhase(phase: Phase): Int = phase.duration(resources = resources)
+
+    /**
+     * Observe the progress of the current phase.
+     */
+    fun phaseProgress(): Observable<Phase.Progress> =
+            timerProgressSubject.asObservable().onBackpressureLatest()
 
     //endregion
 

--- a/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/model/Cycle.kt
@@ -99,10 +99,6 @@ class Cycle
     val remainingTime: Int
         get() = duration - elapsedTime
 
-    /** Indicates whether the current phase time left is about to run out. */
-    val isFinishingPhase: Boolean
-        get() = elapsedTime == duration - 1
-
     //region Observables
 
     /** PublishSubject where we update the timer state. **/

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerActivity.kt
@@ -433,18 +433,18 @@ class TimerActivity : AppCompatActivity(), TimerContract.TimerView {
         break_text.setTime(formattedTime)
     }
 
-    override fun showWorkProgress(progress: Int, maxProgress: Int) {
-        if (work_seek_bar.max != maxProgress.toFloat()) {
-            work_seek_bar.max = maxProgress.toFloat()
+    override fun showWorkProgress(progress: Float, maxProgress: Float) {
+        if (work_seek_bar.max != maxProgress) {
+            work_seek_bar.max = maxProgress
         }
-        animate(seekBar = work_seek_bar, toProgress = -progress.toFloat())
+        animate(seekBar = work_seek_bar, toProgress = -progress)
     }
 
-    override fun showBreakProgress(progress: Int, maxProgress: Int) {
-        if (break_seek_bar.max != maxProgress.toFloat()) {
-            break_seek_bar.max = maxProgress.toFloat()
+    override fun showBreakProgress(progress: Float, maxProgress: Float) {
+        if (break_seek_bar.max != maxProgress) {
+            break_seek_bar.max = maxProgress
         }
-        animate(seekBar = break_seek_bar, toProgress = progress.toFloat())
+        animate(seekBar = break_seek_bar, toProgress = progress)
     }
 
     private fun animate(seekBar: CircularSeekBar, toProgress: Float): ObjectAnimator {

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerContract.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerContract.kt
@@ -95,14 +95,14 @@ interface TimerContract {
          * @param progress The current progress value to display.
          * @param maxProgress The maximum progress value the can be displayed.
          */
-        fun showWorkProgress(progress: Int, maxProgress: Int)
+        fun showWorkProgress(progress: Float, maxProgress: Float)
 
         /**
          * Display break phase progress in the view.
          * @param progress The current progress value to display.
          * @param maxProgress The maximum progress value the can be displayed.
          */
-        fun showBreakProgress(progress: Int, maxProgress: Int)
+        fun showBreakProgress(progress: Float, maxProgress: Float)
 
         /**
          * Change the FloatingActionButton's drawable icon in the view.

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
@@ -111,10 +111,10 @@ class TimerPresenter
 
         subscriptions += cycleTimeText().subscribe { updateTimeText(text = it) }
         subscriptions += workProgress().subscribe {
-            view.showWorkProgress(it.currentProgress, it.maxProgress)
+            view.showWorkProgress(it.current, it.max)
         }
         subscriptions += breakProgress().subscribe {
-            view.showBreakProgress(it.currentProgress, it.maxProgress)
+            view.showBreakProgress(it.current, it.max)
         }
         subscriptions += timerViewMode().subscribe { view.timerMode = it }
 
@@ -147,15 +147,15 @@ class TimerPresenter
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update time string.") }
 
-    private fun cycleProgress(): Observable<Cycle.PhaseProgress> = cycle.timerProgress
+    private fun cycleProgress(): Observable<Cycle.Phase.Progress> = cycle.timerProgress
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update major progress bar.") }
 
-    private fun workProgress(): Observable<Cycle.PhaseProgress> = cycleProgress()
+    private fun workProgress(): Observable<Cycle.Phase.Progress> = cycleProgress()
             .filter { cycle.phase == Cycle.Phase.WORK }
 
-    private fun breakProgress(): Observable<Cycle.PhaseProgress> = cycleProgress()
+    private fun breakProgress(): Observable<Cycle.Phase.Progress> = cycleProgress()
             .filter { cycle.phase == Cycle.Phase.BREAK }
 
     private fun timerViewMode(): Observable<Long> = cycle.timer

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
@@ -30,10 +30,10 @@ import javax.inject.Inject
 
 class TimerPresenter
     @Inject constructor(override var view: TimerContract.TimerView,
-                        val resources: ResourceRepository,
-                        val preferences: RxSharedPreferences,
-                        val cycle: Cycle,
-                        val eventTracker: EventTracker)
+                        private val resources: ResourceRepository,
+                        private val preferences: RxSharedPreferences,
+                        private val cycle: Cycle,
+                        private val eventTracker: EventTracker)
     : TimerContract.UserActionsListener, TimerControl by cycle {
 
     private val context: Context

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
@@ -55,9 +55,74 @@ class TimerPresenter
         aboutComponent.aboutPresenter()
     }
 
-    //region Observers
-
     private lateinit var subscriptions: CompositeSubscription
+
+    /** A recyclable StringBuilder to use when formatting times. */
+    private val timeStringBuilder = StringBuilder(8)
+
+    //region Lifecycle
+
+    override fun onCreate(bundle: Bundle?) {
+        super.onCreate(bundle)
+        Timber.i("Presenter created.")
+    }
+
+    override fun onStart() {
+        super.onStart()
+        updateTimeText()
+
+        startSubscriptions()
+        showTutorialOnFirstRun()
+    }
+
+    private fun updateTimeText(text: String = cycle.remainingTime.toTimeString()) {
+        val nextPhase = cycle.phase.nextPhase
+        val nextDurationText = cycle.durationOfPhase(nextPhase).toTimeString()
+        updateTimeTextForPhase(phase = nextPhase, timeText = nextDurationText)
+
+        updateTimeTextForPhase(phase = cycle.phase, timeText = text)
+    }
+
+    /**
+     * Format a time in seconds as HH:mm:ss when hours are present, mm:ss if the time is less
+     * than an hour, or just as seconds if the time is less than a minute.
+     */
+    private fun Int.toTimeString(): String =
+            if (this >= 60) DateUtils.formatElapsedTime(timeStringBuilder, this.toLong())
+            else "$this"
+
+    private fun updateTimeTextForPhase(phase: Cycle.Phase, timeText: String) = when (phase) {
+        Cycle.Phase.WORK  -> view.showWorkTimeRemaining(formattedTime = timeText)
+        Cycle.Phase.BREAK -> view.showBreakTimeRemaining(formattedTime = timeText)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        subscriptions.unsubscribe()
+    }
+
+    //endregion
+
+
+    //region Observables
+
+    private fun startSubscriptions() {
+        subscriptions = CompositeSubscription()
+
+        subscriptions += cycleTimeText().subscribe { updateTimeText(text = it) }
+        subscriptions += workProgress().subscribe { view.showWorkProgress(it.first, it.second) }
+        subscriptions += breakProgress().subscribe { view.showBreakProgress(it.first, it.second) }
+        subscriptions += timerViewMode().subscribe { view.timerMode = it }
+
+        subscriptions += keepScreenOnPreference().subscribe { view.keepScreenOn = it }
+        subscriptions += allowFullScreenPreference().subscribe { view.fullScreenAllowed = it }
+
+        subscriptions += isCycleRunning().subscribe { running ->
+            Timber.v("Switching play/pause icon.")
+            view.setFABDrawable(if (running) R.drawable.ic_pause
+                                else R.drawable.ic_play_arrow)
+        }
+    }
 
     /**
      * Observe the most recent formatted time for the cycle.
@@ -124,65 +189,6 @@ class TimerPresenter
 
     //endregion
 
-    override fun onCreate(bundle: Bundle?) {
-        super.onCreate(bundle)
-        Timber.i("Presenter created.")
-    }
-
-    override fun onStart() {
-        super.onStart()
-        updateTimeText()
-
-        startSubscriptions()
-        showTutorialOnFirstRun()
-    }
-
-    private fun updateTimeText() {
-        val nextPhase = cycle.phase.nextPhase
-        val nextDurationText = cycle.durationOfPhase(nextPhase).toTimeString()
-        updateTimeTextForPhase(phase = nextPhase, timeText = nextDurationText)
-
-        updateTimeTextForPhase(phase = cycle.phase, timeText = cycle.remainingTime.toTimeString())
-    }
-
-    private fun updateTimeTextForPhase(phase: Cycle.Phase, timeText: String) = when (phase) {
-        Cycle.Phase.WORK  -> view.showWorkTimeRemaining(formattedTime = timeText)
-        Cycle.Phase.BREAK -> view.showBreakTimeRemaining(formattedTime = timeText)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        subscriptions.unsubscribe()
-    }
-
-    private fun startSubscriptions() {
-        subscriptions = CompositeSubscription()
-
-        subscriptions += cycleTimeText().subscribe {
-            when (cycle.phase) {
-                Cycle.Phase.WORK -> {
-                    view.showBreakTimeRemaining(Cycle.Phase.BREAK.duration(resources).toTimeString())
-                    view.showWorkTimeRemaining(it)
-                }
-                Cycle.Phase.BREAK -> {
-                    view.showWorkTimeRemaining(Cycle.Phase.WORK.duration(resources).toTimeString())
-                    view.showBreakTimeRemaining(it)
-                }
-            }
-        }
-        subscriptions += workProgress().subscribe { view.showWorkProgress(it.first, it.second) }
-        subscriptions += breakProgress().subscribe { view.showBreakProgress(it.first, it.second) }
-        subscriptions += timerViewMode().subscribe { view.timerMode = it }
-
-        subscriptions += keepScreenOnPreference().subscribe { view.keepScreenOn = it }
-        subscriptions += allowFullScreenPreference().subscribe { view.fullScreenAllowed = it }
-
-        subscriptions += isCycleRunning().subscribe { running ->
-            Timber.v("Switching play/pause icon.")
-            view.setFABDrawable(if (running) R.drawable.ic_pause
-                                else R.drawable.ic_play_arrow)
-        }
-    }
 
     //region Tutorial display
 
@@ -296,23 +302,6 @@ class TimerPresenter
                 cycle.phaseName.toLowerCase())
         view.showMessage(message = message)
     }
-
-    //endregion
-
-    //region Formatting
-
-    /**
-     * A recyclable StringBuilder to use when formatting times.
-     */
-    private val timeStringBuilder = StringBuilder(8)
-
-    /**
-     * Format a time in seconds as HH:mm:ss when hours are present, mm:ss if the time is less
-     * than an hour, or just as seconds if the time is less than a minute.
-     */
-    private fun Int.toTimeString(): String =
-            if (this >= 60) DateUtils.formatElapsedTime(timeStringBuilder, this.toLong())
-            else "$this"
 
     //endregion
 }

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
@@ -110,8 +110,12 @@ class TimerPresenter
         subscriptions = CompositeSubscription()
 
         subscriptions += cycleTimeText().subscribe { updateTimeText(text = it) }
-        subscriptions += workProgress().subscribe { view.showWorkProgress(it.first, it.second) }
-        subscriptions += breakProgress().subscribe { view.showBreakProgress(it.first, it.second) }
+        subscriptions += workProgress().subscribe {
+            view.showWorkProgress(it.currentProgress, it.maxProgress)
+        }
+        subscriptions += breakProgress().subscribe {
+            view.showBreakProgress(it.currentProgress, it.maxProgress)
+        }
         subscriptions += timerViewMode().subscribe { view.timerMode = it }
 
         subscriptions += keepScreenOnPreference().subscribe { view.keepScreenOn = it }
@@ -143,16 +147,15 @@ class TimerPresenter
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update time string.") }
 
-    private fun cycleProgress(): Observable<Pair<Int, Int>> = cycle.timer
-            .map { Pair(it.elapsedTime, it.duration) }
+    private fun cycleProgress(): Observable<Cycle.PhaseProgress> = cycle.timerProgress
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update major progress bar.") }
 
-    private fun workProgress(): Observable<Pair<Int, Int>> = cycleProgress()
+    private fun workProgress(): Observable<Cycle.PhaseProgress> = cycleProgress()
             .filter { cycle.phase == Cycle.Phase.WORK }
 
-    private fun breakProgress(): Observable<Pair<Int, Int>> = cycleProgress()
+    private fun breakProgress(): Observable<Cycle.PhaseProgress> = cycleProgress()
             .filter { cycle.phase == Cycle.Phase.BREAK }
 
     private fun timerViewMode(): Observable<Long> = cycle.timer

--- a/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
+++ b/app/src/main/java/com/itsronald/twenty2020/timer/TimerPresenter.kt
@@ -147,7 +147,7 @@ class TimerPresenter
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update time string.") }
 
-    private fun cycleProgress(): Observable<Cycle.Phase.Progress> = cycle.timerProgress
+    private fun cycleProgress(): Observable<Cycle.Phase.Progress> = cycle.phaseProgress()
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .onError { Timber.e(it, "Unable to update major progress bar.") }

--- a/app/src/test/java/com/itsronald/twenty2020/model/CycleTest.kt
+++ b/app/src/test/java/com/itsronald/twenty2020/model/CycleTest.kt
@@ -103,25 +103,6 @@ class CycleTest {
     }
 
     @Test
-    fun isFinishingPhase() {
-        val newDuration = 3
-        doReturn("$newDuration").`when`(resources)
-                .getPreferenceString(R.string.pref_key_general_work_phase_length)
-
-        // Skip to next work Cycle to refresh duration to stubbed value.
-        cycle.startNextPhase()
-        cycle.startNextPhase()
-        assertThat(cycle.duration, `is`(newDuration))
-
-        assertThat(cycle.isFinishingPhase, `is`(false))
-
-        cycle.start()
-        Thread.sleep(2500)
-
-        assertThat(cycle.isFinishingPhase, `is`(true))
-    }
-
-    @Test
     fun getDurationMinutes() {
         assertThat(cycle.durationMinutes, `is`(cycle.duration / 60))
     }


### PR DESCRIPTION
When starting the timer, there is a one second delay before the Observables start updating the UI.

This removes the lag by firing some extra events when the timer is started.