### PR TITLE
Bugfix android issue 221397

### DIFF
--- a/app/src/main/res/layout-land/activity_timer.xml
+++ b/app/src/main/res/layout-land/activity_timer.xml
@@ -117,9 +117,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        app:srcCompat="@drawable/ic_play_arrow"
-        app:layout_anchor="@+id/content_layout"
-        app:layout_anchorGravity="bottom|right|end"
-        app:useCompatPadding="true" />
+        android:layout_margin="@dimen/timer_button_layout_margin"
+        app:srcCompat="@drawable/ic_play_arrow" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_timer.xml
+++ b/app/src/main/res/layout/activity_timer.xml
@@ -102,9 +102,8 @@
     <ImageButton
         android:id="@+id/btn_restart_phase"
         android:contentDescription="@string/timer_restart_current_phase"
+        android:layout_gravity="bottom|start"
         app:srcCompat="@drawable/ic_restore_black_24dp"
-        app:layout_anchor="@id/content_layout"
-        app:layout_anchorGravity="bottom|start|left"
         app:layout_dodgeInsetEdges="bottom"
         style="@style/TimerButton" />
 
@@ -112,9 +111,8 @@
         android:id="@+id/timer_fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:srcCompat="@drawable/ic_play_arrow"
-        app:useCompatPadding="true"
-        app:layout_anchor="@id/content_layout"
-        app:layout_anchorGravity="bottom|end|right"/>
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/timer_button_layout_margin"
+        app:srcCompat="@drawable/ic_play_arrow"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Directly invoke layout params instead of support library attributes because of issues with `CoordinatorLayout`anchoring.

See https://code.google.com/p/android/issues/detail?id=221397 for more details.
